### PR TITLE
feat: added labeled and unlabeled trigger events

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ Toolkit.run(
       tools.exit.success()
     }
   },
-  { event: ['pull_request.opened', 'pull_request.edited', 'pull_request.synchronize', 'pull_request.ready_for_review'], secrets: ['GITHUB_TOKEN'] }
+  { event: ['pull_request.opened', 'pull_request.edited', 'pull_request.synchronize', 'pull_request.ready_for_review', 'pull_request.labeled', 'pull_request.unlabeled'], secrets: ['GITHUB_TOKEN'] }
 )
 
 function findFailedCommits(projects, keywords, commitsInPR, ignoreCase) {


### PR DESCRIPTION
We want to trigger this workflow by adding or removing any Label on GitHub PR.
For that, we have extended the allowed triggers with 2 more trigger: `labeled` and `unlabeled`.

[Github Source](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)